### PR TITLE
[jwt토큰 인증 로직 수정 및 캐시적용]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.modelmapper:modelmapper:3.0.0'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation group: 'org.hibernate.validator', name: 'hibernate-validator', version: '7.0.1.Final'

--- a/src/main/java/com/hjj/apiserver/ApiServerApplication.java
+++ b/src/main/java/com/hjj/apiserver/ApiServerApplication.java
@@ -2,9 +2,11 @@ package com.hjj.apiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class ApiServerApplication {
 

--- a/src/main/java/com/hjj/apiserver/ApplicationConfig.java
+++ b/src/main/java/com/hjj/apiserver/ApplicationConfig.java
@@ -7,6 +7,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.hjj.apiserver.config.P6spySqlFormatConfiguration;
+import com.hjj.apiserver.domain.UserEntity;
 import com.hjj.apiserver.dto.TokenDto;
 import com.p6spy.engine.spy.P6SpyOptions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -84,7 +85,7 @@ public class ApplicationConfig implements AuditorAware<Long> {
         if (null == authentication || !authentication.isAuthenticated()) {
             return null;
         }
-        TokenDto user = (TokenDto) authentication.getPrincipal();
+        UserEntity user = (UserEntity) authentication.getPrincipal();
         return Optional.of(user.getUserNo());
     }
 

--- a/src/main/java/com/hjj/apiserver/common/provider/JwtTokenProvider.java
+++ b/src/main/java/com/hjj/apiserver/common/provider/JwtTokenProvider.java
@@ -2,28 +2,34 @@ package com.hjj.apiserver.common.provider;
 
 import com.hjj.apiserver.domain.UserEntity;
 import com.hjj.apiserver.dto.TokenDto;
+import com.hjj.apiserver.service.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-import java.util.Base64;
-import java.util.Date;
-import java.util.HashMap;
+import java.util.*;
 
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider  {
 
-    private static final String AUTHORIZATION_HEADER = "access_token";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
     private static final String AUTHORIZATION_REFRESH_HEADER = "refresh_token";
     private Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -32,6 +38,7 @@ public class JwtTokenProvider  {
 
     private long tokenValidMilisecond = 1000L * 60 * 20; // 20분만 토큰 유효
     private long refreshTokenValidMilisecond = 1000L * 3600 * 24 * 14; // 2주 동안만 토큰 유효
+    private final CustomUserDetailsService customUserDetailsService;
 
 
     public enum TokenKey{
@@ -46,14 +53,15 @@ public class JwtTokenProvider  {
 
     // Jwt AcessToken 생성
     public HashMap<TokenKey, Object> createToken(UserEntity userEntity) {
-        Claims claims = Jwts.claims().setSubject(AUTHORIZATION_HEADER);
-        claims.put("userNo", userEntity.getUserNo());
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userEntity.getUserNo()));
         claims.put("userRole", userEntity.getRole());
         claims.put("userId", userEntity.getUserId());
 
         Date now = new Date();
         long expireTime = new Date().getTime() + tokenValidMilisecond;
-        String token = Jwts.builder().setClaims(claims) // 데이터
+        String token = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims) // 데이터
                 .setIssuedAt(now) // 토큰 발행일자
                 .setExpiration(new Date(expireTime)) // set Expire Time
                 .signWith(SignatureAlgorithm.HS256, secretKey) // 암호화 알고리즘, secret값 세팅
@@ -73,7 +81,9 @@ public class JwtTokenProvider  {
         claims.put("userNo", userEntity.getUserNo());
 
         long expireTime = new Date().getTime() + refreshTokenValidMilisecond;
-        String token = Jwts.builder().setClaims(claims) // 데이터
+        String token = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims) // 데이터
                 .setIssuedAt(new Date()) // 토큰 발행일자
                 .setExpiration(new Date(expireTime)) // set Expire Time
                 .signWith(SignatureAlgorithm.HS256, secretKey) // 암호화 알고리즘, secret값 세팅
@@ -87,9 +97,9 @@ public class JwtTokenProvider  {
     // Jwt 토큰으로 인증 정보를 조회
     public Authentication getAuthentication(String token) {
         Claims claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
-        TokenDto tokenDto = new TokenDto(claims);
+        UserEntity userEntity = (UserEntity) customUserDetailsService.loadUserByUsername(claims.getSubject());
 
-        return new UsernamePasswordAuthenticationToken(tokenDto, "", tokenDto.getAuthorities());
+        return new UsernamePasswordAuthenticationToken(userEntity, "", userEntity.getAuthorities());
     }
 
     // Jwt 토큰으로 TokenDto 객체 반환
@@ -102,8 +112,8 @@ public class JwtTokenProvider  {
      */
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if(StringUtils.hasText(bearerToken)) {
-            return bearerToken;
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
         }
         return null;
     }

--- a/src/main/java/com/hjj/apiserver/config/WebMvcConfiguration.java
+++ b/src/main/java/com/hjj/apiserver/config/WebMvcConfiguration.java
@@ -1,5 +1,6 @@
 package com.hjj.apiserver.config;
 
+import com.hjj.apiserver.util.CurrentUser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Pageable;
@@ -34,7 +35,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer{
     @Bean
     public Docket swaggerApi() {
         return new Docket(DocumentationType.SWAGGER_2)
-                .ignoredParameterTypes(AuthenticationPrincipal.class, Pageable.class) //제외할 파라미터
+                .ignoredParameterTypes(AuthenticationPrincipal.class, Pageable.class, CurrentUser.class) //제외할 파라미터
                 .apiInfo(swaggerInfo()).select()
                 .apis(RequestHandlerSelectors.basePackage("com.hjj.apiserver"))
                 .paths(PathSelectors.any())

--- a/src/main/java/com/hjj/apiserver/controller/AccountBookController.java
+++ b/src/main/java/com/hjj/apiserver/controller/AccountBookController.java
@@ -3,14 +3,14 @@ package com.hjj.apiserver.controller;
 import com.hjj.apiserver.common.ApiError;
 import com.hjj.apiserver.common.ApiResponse;
 import com.hjj.apiserver.common.ApiUtils;
+import com.hjj.apiserver.domain.UserEntity;
 import com.hjj.apiserver.dto.AccountBookDto;
-import com.hjj.apiserver.dto.TokenDto;
 import com.hjj.apiserver.service.AccountBookService;
+import com.hjj.apiserver.util.CurrentUser;
 import io.swagger.annotations.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -24,15 +24,14 @@ public class AccountBookController {
     private final ModelMapper modelMapper;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "가계부 생성", notes = "가계부를 생성 한다.")
     @PostMapping("/account-book")
-    public ApiResponse accountBookAdd(@AuthenticationPrincipal TokenDto tokenDto, @Valid @RequestBody @ApiParam(value = "가계부 생성 객체", required = true) AccountBookDto.RequestAccountBookAddForm form) {
+    public ApiResponse accountBookAdd(@CurrentUser UserEntity user, @Valid @RequestBody @ApiParam(value = "가계부 생성 객체", required = true) AccountBookDto.RequestAccountBookAddForm form) {
         try{
             AccountBookDto accountBookDto = modelMapper.map(form, AccountBookDto.class);
-            accountBookDto.setUserNo(tokenDto.getUserNo());
 
-            accountBookService.addAccountBook(accountBookDto);
+            accountBookService.addAccountBook(user, accountBookDto);
 
             return ApiUtils.success(null);
         }catch (Exception e){
@@ -41,13 +40,13 @@ public class AccountBookController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "개인가계부 목록을 조회.", notes = "개인가계부를 조회 한다.")
     @GetMapping("/account-book")
-    public ApiResponse accountBookFindAll(@AuthenticationPrincipal TokenDto tokenDto, @Valid AccountBookDto.RequestAccountBookFindAllForm form) {
+    public ApiResponse accountBookList(@CurrentUser UserEntity user, @Valid AccountBookDto.RequestAccountBookFindAllForm form) {
         try{
             AccountBookDto accountBookDto = modelMapper.map(form, AccountBookDto.class);
-            accountBookDto.setUserNo(tokenDto.getUserNo());
+            accountBookDto.setUserNo(user.getUserNo());
             return ApiUtils.success(accountBookService.findAllAccountBook(accountBookDto));
         }catch (Exception e){
             return ApiUtils.error(ApiError.ErrCode.ERR_CODE9999.getMsg(), ApiError.ErrCode.ERR_CODE9999);
@@ -55,13 +54,13 @@ public class AccountBookController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "개인가계부 상세 조회.", notes = "개인가계부를 상세 조회 한다.")
     @GetMapping("/account-book/{accountBookNo}")
-    public ApiResponse accountBookFindDetail(@AuthenticationPrincipal TokenDto tokenDto, @PathVariable Long accountBookNo) {
+    public ApiResponse accountBookDetails(@CurrentUser UserEntity user, @PathVariable Long accountBookNo) {
         try{
             AccountBookDto accountBookDto = new AccountBookDto();
-            accountBookDto.setUserNo(tokenDto.getUserNo());
+            accountBookDto.setUserNo(user.getUserNo());
             accountBookDto.setAccountBookNo(accountBookNo);
 
             return ApiUtils.success(accountBookService.findAccountBookDetail(accountBookDto));

--- a/src/main/java/com/hjj/apiserver/controller/CardController.java
+++ b/src/main/java/com/hjj/apiserver/controller/CardController.java
@@ -5,15 +5,15 @@ import com.hjj.apiserver.common.ApiResponse;
 import com.hjj.apiserver.common.ApiUtils;
 import com.hjj.apiserver.common.provider.JwtTokenProvider;
 import com.hjj.apiserver.domain.CardEntity;
+import com.hjj.apiserver.domain.UserEntity;
 import com.hjj.apiserver.dto.CardDto;
-import com.hjj.apiserver.dto.TokenDto;
 import com.hjj.apiserver.repositroy.CardRepository;
 import com.hjj.apiserver.repositroy.UserRepository;
 import com.hjj.apiserver.service.CardService;
+import com.hjj.apiserver.util.CurrentUser;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,10 +31,10 @@ public class CardController {
     private final CardService cardService;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "개인 카드 목록 조회", notes = "개인카드 목록조회한다..")
     @GetMapping("/card")
-    public ApiResponse<List<CardDto>> getCardList(@AuthenticationPrincipal TokenDto user) {
+    public ApiResponse<List<CardDto>> cardList(@CurrentUser UserEntity user) {
         List<CardEntity> cardEntityList = cardRepository.findByUserEntity_UserNoAndDeleteYn(user.getUserNo(), 'N');
         List<CardDto> cardDto = cardEntityList.stream().map(tempCardEntity -> modelMapper.map(tempCardEntity, CardDto.class)).collect(Collectors.toList());
 
@@ -43,10 +43,10 @@ public class CardController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "개인 카드 등록", notes = "개인카드 등록한다.")
     @PostMapping("/card")
-    public ApiResponse addCard(@AuthenticationPrincipal TokenDto user, @RequestBody CardDto.RequestAddCardForm requestAddCardForm) {
+    public ApiResponse cardAdd(@CurrentUser UserEntity user, @RequestBody CardDto.RequestAddCardForm requestAddCardForm) {
         try {
             CardDto cardDto = modelMapper.map(requestAddCardForm, CardDto.class);
             cardDto.setUserEntity(userRepository.getById(user.getUserNo()));
@@ -59,13 +59,13 @@ public class CardController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(httpMethod = "DELETE"
             ,value = "개인 카드 삭제"
             ,notes = "개인 카드를 삭제한다."
             ,responseContainer = "Integer")
     @DeleteMapping("/card/{cardNo}")
-    public ApiResponse deleteCard(@AuthenticationPrincipal TokenDto user ,@ApiParam(value = "cardNo", required = true) @PathVariable("cardNo") Long cardNo) {
+    public ApiResponse cardRemove(@CurrentUser UserEntity user ,@ApiParam(value = "cardNo", required = true) @PathVariable("cardNo") Long cardNo) {
 
         try {
             CardEntity cardEntity = cardRepository.findByCardNoAndUserEntity_UserNo(cardNo, user.getUserNo()).orElseThrow(() -> new Exception("해당된 값이 없습니다."));
@@ -78,13 +78,13 @@ public class CardController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(httpMethod = "PUT"
             ,value = "개인 카드 수정"
             ,notes = "개인 카드를 삭제한다."
             ,responseContainer = "Integer")
     @PutMapping("/card/{cardNo}")
-    public ApiResponse updateCard(@AuthenticationPrincipal TokenDto user ,@ApiParam(value = "cardNo", required = true) @PathVariable("cardNo") Long cardNo, @RequestBody CardDto.RequestModifyCardForm modifyCardForm) {
+    public ApiResponse cardModify(@CurrentUser UserEntity user ,@ApiParam(value = "cardNo", required = true) @PathVariable("cardNo") Long cardNo, @RequestBody CardDto.RequestModifyCardForm modifyCardForm) {
         try {
             CardEntity cardEntity = cardRepository.findByCardNoAndUserEntity_UserNo(cardNo, user.getUserNo()).orElseThrow(() -> new Exception("해당된 값이 없습니다."));
             cardService.updateCard(cardEntity, modifyCardForm.getCardDto());
@@ -96,13 +96,13 @@ public class CardController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(httpMethod = "GET"
             ,value = "개인 카드 상세"
             ,notes = "개인 카드 상세확인페이지"
             ,responseContainer = "Integer")
     @GetMapping("/card/{cardNo}")
-    public ApiResponse selectCardDetail(@AuthenticationPrincipal TokenDto user ,@ApiParam(value = "cardNo", required = true) @PathVariable("cardNo") Long cardNo) {
+    public ApiResponse cardDetails(@CurrentUser UserEntity user ,@ApiParam(value = "cardNo", required = true) @PathVariable("cardNo") Long cardNo) {
         try {
             CardEntity cardEntity = cardRepository.findByCardNoAndUserEntity_UserNo(cardNo, user.getUserNo()).orElseThrow(() -> new Exception("해당된 값이 없습니다."));
             CardDto cardDto = modelMapper.map(cardEntity, CardDto.class);

--- a/src/main/java/com/hjj/apiserver/controller/CategoryController.java
+++ b/src/main/java/com/hjj/apiserver/controller/CategoryController.java
@@ -3,14 +3,14 @@ package com.hjj.apiserver.controller;
 import com.hjj.apiserver.common.ApiError;
 import com.hjj.apiserver.common.ApiResponse;
 import com.hjj.apiserver.common.ApiUtils;
+import com.hjj.apiserver.domain.UserEntity;
 import com.hjj.apiserver.dto.CategoryDto;
-import com.hjj.apiserver.dto.TokenDto;
 import com.hjj.apiserver.service.CategoryService;
+import com.hjj.apiserver.util.CurrentUser;
 import io.swagger.annotations.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -24,10 +24,10 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "카테고리 등록", notes = "카테고리를 등록한다.")
     @PostMapping("/category")
-    public ApiResponse categoryAdd(@AuthenticationPrincipal TokenDto user, @RequestBody CategoryDto.RequestCategoryAddForm form) {
+    public ApiResponse categoryAdd(@CurrentUser UserEntity user, @RequestBody CategoryDto.RequestCategoryAddForm form) {
         try {
             CategoryDto categoryDto = modelMapper.map(form, CategoryDto.class);
             categoryDto.setUserNo(user.getUserNo());
@@ -41,10 +41,10 @@ public class CategoryController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "카테고리 리스트를 반환", notes = "카테고리를 리스트를 반환한다.")
     @GetMapping("/category")
-    public ApiResponse categoryList(@AuthenticationPrincipal TokenDto user, @RequestParam(value = "accountBookNo") Long accountBookNo) {
+    public ApiResponse categoryList(@CurrentUser UserEntity user, @RequestParam(value = "accountBookNo") Long accountBookNo) {
         try {
             return ApiUtils.success(categoryService.findAllCategory(user.getUserNo(), accountBookNo));
         } catch (Exception e) {
@@ -54,10 +54,10 @@ public class CategoryController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "카테고리 상세 조회", notes = "카테고리를 상세 조회한다.")
     @GetMapping("/category/{categoryNo}")
-    public ApiResponse categoryDetail(@AuthenticationPrincipal TokenDto user, @ApiParam(value = "categoryNo", required = true) @PathVariable("categoryNo") Long categoryNo) {
+    public ApiResponse categoryDetails(@CurrentUser UserEntity user, @ApiParam(value = "categoryNo", required = true) @PathVariable("categoryNo") Long categoryNo) {
         try {
 
             return ApiUtils.success(categoryService.findCategory(categoryNo));
@@ -68,10 +68,10 @@ public class CategoryController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "카테고리를 변경", notes = "카테고리를 변경한다.")
     @PatchMapping("/category/{categoryNo}")
-    public ApiResponse categoryModify(@AuthenticationPrincipal TokenDto user, @ApiParam(value = "categoryNo", required = true) @PathVariable("categoryNo") Long categoryNo, @Valid @RequestBody CategoryDto.RequestCategoryModifyForm form) {
+    public ApiResponse categoryModify(@CurrentUser UserEntity user, @ApiParam(value = "categoryNo", required = true) @PathVariable("categoryNo") Long categoryNo, @Valid @RequestBody CategoryDto.RequestCategoryModifyForm form) {
         try {
             CategoryDto categoryDto = modelMapper.map(form, CategoryDto.class);
             categoryDto.setUserNo(user.getUserNo());
@@ -87,10 +87,10 @@ public class CategoryController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "카테고리를 삭제", notes = "카테고리를 삭제한다.")
     @DeleteMapping("/category/{categoryNo}")
-    public ApiResponse categoryDelete(@AuthenticationPrincipal TokenDto user, @ApiParam(value = "categoryNo", required = true) @PathVariable("categoryNo") Long categoryNo, @RequestBody CategoryDto.RequestCategoryRemoveForm form) {
+    public ApiResponse categoryRemove(@CurrentUser UserEntity user, @ApiParam(value = "categoryNo", required = true) @PathVariable("categoryNo") Long categoryNo, @RequestBody CategoryDto.RequestCategoryRemoveForm form) {
         try {
             categoryService.deleteCategory(categoryNo, form.getAccountBookNo(), user.getUserNo());
 

--- a/src/main/java/com/hjj/apiserver/controller/PurchaseController.java
+++ b/src/main/java/com/hjj/apiserver/controller/PurchaseController.java
@@ -3,18 +3,15 @@ package com.hjj.apiserver.controller;
 import com.hjj.apiserver.common.ApiError;
 import com.hjj.apiserver.common.ApiResponse;
 import com.hjj.apiserver.common.ApiUtils;
+import com.hjj.apiserver.domain.UserEntity;
 import com.hjj.apiserver.dto.PurchaseDto;
-import com.hjj.apiserver.dto.TokenDto;
-import com.hjj.apiserver.repositroy.AccountBookRepository;
-import com.hjj.apiserver.service.CardService;
-import com.hjj.apiserver.service.CategoryService;
 import com.hjj.apiserver.service.PurchaseService;
+import com.hjj.apiserver.util.CurrentUser;
 import io.swagger.annotations.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Api(tags = {"3. Purchase"})
@@ -27,10 +24,10 @@ public class PurchaseController {
     private final PurchaseService purchaseService;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "지출,수입 등록", notes = "지출, 수입을 등록한다.")
     @PostMapping("/purchase")
-    public ApiResponse purchaseAdd(@AuthenticationPrincipal TokenDto user, @RequestBody PurchaseDto.RequestAddPurchaseForm requestAddPurchaseForm) {
+    public ApiResponse purchaseAdd(@CurrentUser UserEntity user, @RequestBody PurchaseDto.RequestAddPurchaseForm requestAddPurchaseForm) {
         try {
             PurchaseDto purchaseDto = modelMapper.map(requestAddPurchaseForm, PurchaseDto.class);
             purchaseDto.setUserNo(user.getUserNo());
@@ -45,10 +42,10 @@ public class PurchaseController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "지출,수입 리스트", notes = "지출, 수입을 리스트를 불러온다.")
     @GetMapping("/purchase")
-    public ApiResponse purchaseFindList(@AuthenticationPrincipal TokenDto user, PurchaseDto.RequestPurchaseFindForm form) {
+    public ApiResponse purchaseList(@CurrentUser UserEntity user, PurchaseDto.RequestPurchaseFindForm form) {
         try {
             PageRequest pageRequest = PageRequest.of(form.getPage(), form.getSize());
             PurchaseDto purchaseDto = modelMapper.map(form, PurchaseDto.class);
@@ -63,10 +60,10 @@ public class PurchaseController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "지출,수입 삭제", notes = "지출, 수입을 삭제한다.")
     @DeleteMapping("/purchase/{purchaseNo}")
-    public ApiResponse purchaseDelete(@AuthenticationPrincipal TokenDto user, @PathVariable("purchaseNo") Long purchaseNo) {
+    public ApiResponse purchaseRemove(@CurrentUser UserEntity user, @PathVariable("purchaseNo") Long purchaseNo) {
         try {
 
             purchaseService.deletePurchase(user.getUserNo(), purchaseNo);
@@ -80,10 +77,10 @@ public class PurchaseController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "지출, 수입 상세조회", notes = "지출, 수입을 상세 조회한다.")
     @GetMapping("/purchase/{purchaseNo}")
-    public ApiResponse purchaseDetail(@AuthenticationPrincipal TokenDto user, @PathVariable("purchaseNo") Long purchaseNo) {
+    public ApiResponse purchaseDetails(@CurrentUser UserEntity user, @PathVariable("purchaseNo") Long purchaseNo) {
         try {
             return ApiUtils.success(purchaseService.findPurchase(user.getUserNo(), purchaseNo));
         } catch (Exception e) {
@@ -93,10 +90,10 @@ public class PurchaseController {
     }
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "access_token", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")})
     @ApiOperation(value = "지출, 수입 수정", notes = "지출, 수입을 수정한다.")
     @PatchMapping("/purchase/{purchaseNo}")
-    public ApiResponse purchaseModify(@AuthenticationPrincipal TokenDto user, @ApiParam(value = "purchaseNo", required = true) @PathVariable("purchaseNo") Long purchaseNo, @RequestBody PurchaseDto.RequestModifyPurchaseForm form) {
+    public ApiResponse purchaseModify(@CurrentUser UserEntity user, @ApiParam(value = "purchaseNo", required = true) @PathVariable("purchaseNo") Long purchaseNo, @RequestBody PurchaseDto.RequestModifyPurchaseForm form) {
         try {
             PurchaseDto purchaseDto = modelMapper.map(form, PurchaseDto.class);
             purchaseDto.setPurchaseNo(purchaseNo);

--- a/src/main/java/com/hjj/apiserver/domain/UserEntity.java
+++ b/src/main/java/com/hjj/apiserver/domain/UserEntity.java
@@ -121,7 +121,7 @@ public class UserEntity implements UserDetails {
 
     @Override
     public String getUsername() {
-        return userId;
+        return String.valueOf(userNo);
     }
 
     @Override   //계정이 만료가 안되었는지

--- a/src/main/java/com/hjj/apiserver/dto/UserDto.java
+++ b/src/main/java/com/hjj/apiserver/dto/UserDto.java
@@ -1,10 +1,11 @@
 package com.hjj.apiserver.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hjj.apiserver.domain.UserEntity;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -110,5 +111,22 @@ public class UserDto {
         private String accessToken;
         private String refreshToken;
         private long expireTime;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ResponseUserDetails{
+        private Long userNo;
+        private String userId;
+        private String nickName;
+        private String userEmail;
+        private UserEntity.Provider provider;
+        private UserEntity.Role role;
+        private LocalDateTime providerConnectDate;
+        private LocalDateTime createdDate;
+        private LocalDateTime lastLoginDateTime;
+
+
     }
 }

--- a/src/main/java/com/hjj/apiserver/repositroy/UserRepository.java
+++ b/src/main/java/com/hjj/apiserver/repositroy/UserRepository.java
@@ -7,10 +7,9 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<UserEntity, Long>, UserRepositoryCustom {
     Optional<UserEntity> findByUserId(String userId);
     Optional<UserEntity> findByProviderAndProviderId(UserEntity.Provider provider, String providerId);
-    Optional<UserEntity> findByUserNo(Long userNo);
     Boolean existsUserEntityByProviderIdAndProviderAndDeleteYn(String providerId, UserEntity.Provider provider, char deletedYn);
     Boolean existsUserEntityByUserId(String UserId);
     Boolean existsUserEntityByNickNameAndUserNoNot(String nickName, Long userNo);

--- a/src/main/java/com/hjj/apiserver/repositroy/UserRepositoryCustom.java
+++ b/src/main/java/com/hjj/apiserver/repositroy/UserRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.hjj.apiserver.repositroy;
+
+import com.hjj.apiserver.domain.UserEntity;
+import com.hjj.apiserver.dto.UserDto;
+
+import java.util.Optional;
+
+public interface UserRepositoryCustom {
+    UserEntity findUserLeftJoinUserLogByUserNo(Long userNo);
+}

--- a/src/main/java/com/hjj/apiserver/repositroy/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/hjj/apiserver/repositroy/impl/UserRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.hjj.apiserver.repositroy.impl;
+
+import com.hjj.apiserver.domain.QUserEntity;
+import com.hjj.apiserver.domain.QUserLogEntity;
+import com.hjj.apiserver.domain.UserEntity;
+import com.hjj.apiserver.dto.QUserDto_ResponseUserDetails;
+import com.hjj.apiserver.dto.UserDto;
+import com.hjj.apiserver.repositroy.UserRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.hjj.apiserver.domain.QUserEntity.*;
+import static com.hjj.apiserver.domain.QUserLogEntity.*;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public UserEntity findUserLeftJoinUserLogByUserNo(Long userNo) {
+
+        return jpaQueryFactory
+                .select(userEntity)
+                .from(userEntity)
+                .leftJoin(userEntity.userLogEntityList, userLogEntity).fetchJoin()
+                .where(userEntity.userNo.eq(userNo))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/hjj/apiserver/service/AccountBookService.java
+++ b/src/main/java/com/hjj/apiserver/service/AccountBookService.java
@@ -32,8 +32,7 @@ public class AccountBookService {
 
 
     @Transactional(readOnly = false, rollbackFor = Exception.class)
-    public void addAccountBook(AccountBookDto accountBookDto) throws UserNotFoundException {
-        UserEntity userEntity = userRepository.findByUserNo(accountBookDto.getUserNo()).orElseThrow(UserNotFoundException::new);
+    public void addAccountBook(UserEntity user, AccountBookDto accountBookDto) throws UserNotFoundException {
 
         AccountBookEntity accountBookEntity = accountBookDto.toEntity();
         accountBookRepository.save(accountBookEntity);
@@ -42,7 +41,7 @@ public class AccountBookService {
         AccountBookUserDto accountBookUserDto = new AccountBookUserDto();
         accountBookUserDto.setAccountBookEntity(accountBookEntity);
         accountBookUserDto.setAccountRole(AccountBookUserEntity.AccountRole.OWNER);
-        accountBookUserDto.setUserEntity(userEntity);
+        accountBookUserDto.setUserEntity(user);
         accountBookUserDto.setBackGroundColor(accountBookDto.getBackGroundColor());
         accountBookUserDto.setColor(accountBookDto.getColor());
         AccountBookUserEntity accountBookUserEntity = accountBookUserDto.toEntity();

--- a/src/main/java/com/hjj/apiserver/service/CustomUserDetailsService.java
+++ b/src/main/java/com/hjj/apiserver/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.hjj.apiserver.service;
+
+import com.hjj.apiserver.repositroy.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    @Cacheable(value = "users", key = "#username")
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findById(Long.valueOf(username)).orElseThrow(() -> new UsernameNotFoundException("사용자가 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/com/hjj/apiserver/util/CurrentUser.java
+++ b/src/main/java/com/hjj/apiserver/util/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.hjj.apiserver.util;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this")
+public @interface CurrentUser {
+}

--- a/src/test/java/com/hjj/apiserver/repositroy/UserRepositoryTest.java
+++ b/src/test/java/com/hjj/apiserver/repositroy/UserRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.hjj.apiserver.repositroy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hjj.apiserver.domain.QUserEntity;
+import com.hjj.apiserver.domain.QUserLogEntity;
+import com.hjj.apiserver.domain.UserEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.hjj.apiserver.domain.QUserEntity.*;
+import static com.hjj.apiserver.domain.QUserLogEntity.*;
+
+@SpringBootTest
+@Transactional
+class UserRepositoryTest {
+    @Autowired private JPAQueryFactory jpaQueryFactory;
+    @Autowired private ObjectMapper objectMapper;
+
+
+    @Test
+    void findUserJoinUserLogByUserNo() throws JsonProcessingException {
+        UserEntity user = jpaQueryFactory
+                .select(userEntity)
+                .from(userEntity)
+                .leftJoin(userEntity.userLogEntityList, userLogEntity)
+                .where(userEntity.userNo.eq(1L))
+                .fetchOne();
+
+        user.getUserLogEntityList().forEach(System.out::println);
+    }
+
+}


### PR DESCRIPTION
- 기존: tokenDto => @CurrentUser 어노테이션 추가하여 인증정보 활용하도록 수정
- api 호출할때 사용자정보 캐쉬에 있는경우 그대로 사용

[유저 상세조회 API 추가]