### PR TITLE
[가계부]

### DIFF
--- a/src/main/kotlin/com/hjj/apiserver/controller/UserController.kt
+++ b/src/main/kotlin/com/hjj/apiserver/controller/UserController.kt
@@ -34,8 +34,8 @@ class UserController(
 
     @ApiOperation(value = "유저닉네임 중복 조회", notes = "유저닉네임의 중복여부를 확인한다.")
     @GetMapping("/user/{nickName}/exists-nickname")
-    fun checkUserNickNameDuplicate(@PathVariable nickName: String): ApiResponse<*> {
-        return ApiUtils.success(userService.existsNickName(nickName))
+    fun checkUserNickNameDuplicate(@CurrentUser currentUserInfo: CurrentUserInfo?, @PathVariable nickName: String): ApiResponse<*> {
+        return ApiUtils.success(userService.existsNickName(currentUserInfo, nickName))
     }
 
     @ApiOperation(value = "유저Id 중복 조회", notes = "유저id의 중복여부를 확인한다.")

--- a/src/main/kotlin/com/hjj/apiserver/repository/accountbook/AccountBookRepositoryImpl.kt
+++ b/src/main/kotlin/com/hjj/apiserver/repository/accountbook/AccountBookRepositoryImpl.kt
@@ -25,6 +25,7 @@ class AccountBookRepositoryImpl(
                     .from(accountBookUser)
                     .where(
                         accountBookUser.user.userNo.eq(userNo),
+                        accountBookUser.accountBook.accountBookNo.eq(accountBookNo),
                         accountBookUser.accountRole.`in`(accountRoles)
                     )
                 )

--- a/src/main/kotlin/com/hjj/apiserver/repository/category/CategoryRepositoryImpl.kt
+++ b/src/main/kotlin/com/hjj/apiserver/repository/category/CategoryRepositoryImpl.kt
@@ -78,7 +78,8 @@ class CategoryRepositoryImpl(
                             JPAExpressions.select(accountBookUser.accountBook.accountBookNo)
                                 .from(accountBookUser)
                                 .where(
-                                    accountBookUser.user.userNo.eq(userNo)
+                                    accountBookUser.user.userNo.eq(userNo),
+                                    accountBookUser.accountBook.accountBookNo.eq(accountBookNo)
                                         .and(accountBookUser.accountRole.`in`(accountRoles))
                                 )
                         )

--- a/src/main/kotlin/com/hjj/apiserver/service/UserService.kt
+++ b/src/main/kotlin/com/hjj/apiserver/service/UserService.kt
@@ -6,6 +6,7 @@ import com.hjj.apiserver.common.exception.AlreadyExistedUserException
 import com.hjj.apiserver.common.exception.ExistedSocialUserException
 import com.hjj.apiserver.common.exception.UserNotFoundException
 import com.hjj.apiserver.domain.user.*
+import com.hjj.apiserver.dto.user.CurrentUserInfo
 import com.hjj.apiserver.dto.user.request.UserModifyRequest
 import com.hjj.apiserver.dto.user.request.UserSignInRequest
 import com.hjj.apiserver.dto.user.request.UserSinUpRequest
@@ -76,8 +77,13 @@ class UserService(
     private val log = logger()
 
 
-    fun existsNickName(nickName: String): Boolean {
-        return userRepository.findExistsUserNickName(nickName)
+    fun existsNickName(currentUserInfo: CurrentUserInfo?, nickName: String): Boolean {
+        /* 자기자신의 닉네임과 동일 한 경우 true 리턴 */
+        return if (currentUserInfo?.nickName == nickName) {
+            true
+        } else {
+            userRepository.findExistsUserNickName(nickName)
+        }
     }
 
     fun existsUserId(userId: String): Boolean {


### PR DESCRIPTION
- 2개 이상의 가계부에 속해있을때 쿼리문 버그 수정(subquery 리턴값이 2개임)
[카테고리]
- 카테고리 수정시에 권한확인 query에서 가계부번호 where절 누락 수정
[유저]
- 사용자 닉네임 체크시 자기자신은 예외처리하도록 수정